### PR TITLE
Don't find hidden teamspeak directories

### DIFF
--- a/TS3UpdateScript.sh
+++ b/TS3UpdateScript.sh
@@ -538,7 +538,7 @@ if [ "$AUTO_UPDATE_PARAMETER" != "no" ]; then
 			exit 1;
 		fi
 	else
-		if [ ! $(find / -name 'ts3server_startscript.sh' 2> /dev/null | grep -v '/tmp/ts3server_backup' | sort > TeamSpeak_Directories.txt) ]; then
+		if [ ! $(find / -name 'ts3server_startscript.sh' -not -path '*/\.*' 2> /dev/null | grep -v '/tmp/ts3server_backup' | sort > TeamSpeak_Directories.txt) ]; then
 			if [ "$CRONJOB_AUTO_UPDATE" == "true" ]; then
 				echo -e "\t[ OK ]\n";
 			else


### PR DESCRIPTION
I use different test-installations of TeamSpeak3 which I move to .bak if not needed.

The script finds them and tries to update - just skip .hidden directories with this change